### PR TITLE
Fix PDEBUILD/Launchpad Build Errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Build-Depends:
 # Debian build system
- , debhelper (>= 9), autoconf
+ , debhelper (>= 9), autoconf, automake, libtool
 # C/C++
  , zlib1g-dev
  , libgtest-dev


### PR DESCRIPTION
The build error message says that we need
automake and libtool.

CC: @again4you

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>