### PR TITLE
[Dist/Debian] Revise debian/rules file to fix debuild error

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,201 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: protobuf
+Source: https://github.com/google/protobuf
+Comment:
+ This package was originally debianized by Iustin Pop <iusty@k1024.org>
+ on Mon, 07 Jul 2008 17:48:21 +0200.
+ Based on the debianized work previously done by others, this package was
+ debianized by the NNStreamer team  (https://github.com/nnsuite/nnstreamer)
+ on Fri, 18 Jan 2018 13:37:33 +0900. Note that we only releases the sub-packages
+ of protobuf required by NNStreamer to back-port support.
+
+Files: *
+Copyright: 2008-2018 Google Inc.
+License: BSD-3-Clause~Google
+
+Files:
+    src/google/protobuf/stubs/atomicops_internals_power.h
+Copyright: 2014 Bloomberg Finance LP
+License: BSD-3-Clause~Bloomberg
+
+Files:
+    src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+Copyright: 2013 Red Hat Inc
+License: BSD-3-Clause~RedHat
+
+Files: m4/acx_pthread.m4
+Copyright: 2006 Steven G. Johnson <stevenj@alum.mit.edu>
+License: GPLWithACException
+ This program is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the Free
+ Software Foundation. As a special exception, the respective Autoconf
+ Macro's copyright owner gives unlimited permission to copy, distribute and
+ modify the configure scripts that are the output of Autoconf when
+ processing the Macro. You need not follow the terms of the GNU General
+ Public License when using or distributing such scripts.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License can be found in "/usr/share/common-licenses/GPL-2".
+Comment:
+ Unspecified GPL, assuming any version as per text of the GPL-2 license:
+   "If the Program does not specify a version number of this License, you may
+    choose any version ever published by the Free Software Foundation."
+
+Files:
+    python/mox.py
+    python/stubout.py
+Copyright: 2008 Google Inc.
+License: Apache-2.0
+
+Files: conformance/third_party/jsoncpp/*
+Copyright: 2007-2010 Baptiste Lepilleur
+License: Public-Domain or Expat
+
+Files: debian/*
+Copyright:
+    2009      Dirk Eddelbuettel <edd@debian.org>
+    2016      Dmitry Smirnov <onlyjob@debian.org>
+    2009      Julien Cristau <jcristau@debian.org>
+    2013-2014 Robert Edmonds <edmonds@debian.org>
+    2008,2009,2010 Iustin Pop <iusty@k1024.org>
+    2016-     Laszlo Boszormenyi (GCS) <gcs@debian.org>
+License: GPL-3
+
+License: Public-Domain
+ The author explicitly disclaims copyright in all jurisdictions which
+ recognize such a disclaimer. In such jurisdictions, this software is
+ released into the Public Domain.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ ․
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ ․
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+License: BSD-3-Clause~Google
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following disclaimer
+      in the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Comment:
+ Code generated by the Protocol Buffer compiler is owned by the owner
+ of the input file used when generating it.  This code is not
+ standalone and requires a support library to be linked with it.
+ This support library is itself covered by the above license.
+
+License: BSD-3-Clause~Bloomberg
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following disclaimer
+       in the documentation and/or other materials provided with the
+       distribution.
+     * Neither the name of Bloomberg Finance LP. nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD-3-Clause~RedHat
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following disclaimer
+       in the documentation and/or other materials provided with the
+       distribution.
+     * Neither the name of Red Hat Inc. nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ ․
+    https://www.apache.org/licenses/LICENSE-2.0
+ ․
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ․
+ On Debian systems, the complete text of the Apache License,
+ Version 2.0 can be found in "/usr/share/common-licenses/Apache-2.0".
+
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+ ․
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ ․
+ On Debian systems, the complete text of the GNU General Public
+ License Version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,12 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+ifeq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+export DEB_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+else
+export DEB_MULTIARCH ?= $(shell dpkg-architecture -qDEB_BUILD_MULTIARCH)
+endif
+
 include /usr/share/dpkg/architecture.mk
 ifeq ($(origin CXX),default)
 CXX := $(DEB_HOST_GNU_TYPE)-g++
@@ -13,16 +19,19 @@ endif
 %:
 	dh $@
 
-ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+PROTOBUF_INSTALL_PREFIX=/usr
+PROTOBUF_INSTALL_LIBDIR=$(PROTOBUF_INSTALL_PREFIX)/lib/$(DEB_MULTIARCH)
+
 override_dh_auto_configure:
 	NOCONFIGURE=1 ./autogen.sh
-	dh_auto_configure -- --host=$(DEB_BUILD_GNU_TYPE)
+ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+	dh_auto_configure -- --host=$(DEB_BUILD_GNU_TYPE) --prefix=$(PROTOBUF_INSTALL_PREFIX) --libdir=$(PROTOBUF_INSTALL_LIBDIR)
 
+else
+	dh_auto_configure -- --prefix=$(PROTOBUF_INSTALL_PREFIX) --libdir=$(PROTOBUF_INSTALL_LIBDIR)
 endif
 
 override_dh_auto_build-arch:
-	NOCONFIGURE=1 ./autogen.sh
-	sh ./configure
 	dh_auto_build --arch
 	bash -x ./generate_descriptor_proto.sh
 
@@ -35,7 +44,6 @@ endif
 
 override_dh_auto_build-indep:
 	dh_auto_build --indep
-
 
 override_dh_clean:
 	$(RM) -rv gmock


### PR DESCRIPTION
Related issue: https://github.com/nnsuite/nnstreamer/issues/1039

In this PR, 
- a Debian-format copyright file to the ```debian``` directory
- the rules file is revised to fix build error in out PPA

This PR is work-in-progress; I am testing this PR on my launchpad PPA.
We need to confirm that 1) building and releasing at launchpad PPA are ready and 2) the deb files downloaded from that PPA properly works with tensorflow/nnstreamer.

Signed-off-by: Wook Song <wook16.song@samsung.com>