### PR TITLE
[Dist/Debian] Fix install conflict by revising debian/*.install files

### DIFF
--- a/debian/libprotobuf-dev.install
+++ b/debian/libprotobuf-dev.install
@@ -2,5 +2,6 @@
 /usr/lib/*/libprotobuf-lite.a
 /usr/lib/*/libprotobuf.so
 /usr/lib/*/libprotobuf-lite.so
-/usr/lib/*/pkgconfig/*
-/usr/include
+/usr/lib/*/pkgconfig/protobuf-lite.pc
+/usr/lib/*/pkgconfig/protobuf.pc
+/usr/include/google/protobuf/*

--- a/debian/libprotobuf17.install
+++ b/debian/libprotobuf17.install
@@ -1,1 +1,2 @@
-/usr/lib/*/libprotobuf.so.*
+/usr/lib/*/libprotobuf.so.17.*
+/usr/lib/*/libprotobuf.so.17

--- a/debian/libprotoc-dev.install
+++ b/debian/libprotoc-dev.install
@@ -1,3 +1,3 @@
 /usr/lib/*/libprotoc.a
 /usr/lib/*/libprotoc.so
-/usr/include/google/protobuf/compiler
+/usr/include/google/protobuf/compiler/*

--- a/debian/libprotoc17.install
+++ b/debian/libprotoc17.install
@@ -1,1 +1,2 @@
-/usr/lib/*/libprotoc*.so.*
+/usr/lib/*/libprotoc*.so.17.*
+/usr/lib/*/libprotoc*.so.17


### PR DESCRIPTION
Related issue: nnsuite/nnstreamer#1039

This patch fixes errors in debian/*.install files so that install conflicts between deb files are resolved.

Signed-off-by: Wook Song <wook16.song@samsung.com>