### PR TITLE
[Dist/Debian] Remove header files from libprotoc-dev package

### DIFF
--- a/debian/libprotoc-dev.install
+++ b/debian/libprotoc-dev.install
@@ -1,3 +1,2 @@
 /usr/lib/*/libprotoc.a
 /usr/lib/*/libprotoc.so
-/usr/include/google/protobuf/compiler/*


### PR DESCRIPTION
Since libprotoc-dev has a run dependency on libprotobuf-dev, header files included in libprotoc-dev may conflict with those of libprotobuf-dev. To solve this issue, this patch removes header files form the libprotoc-dev package.

Signed-off-by: Wook Song <wook16.song@samsung.com>